### PR TITLE
Fix failed import of serde::export::Formatter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ readme = "README.md"
 keywords = ["badge", "maker", "svg", "shield"]
 include = ["src/", "Cargo.toml", "fonts/verdana-11px-normal.bincode"]
 
+[[bin]]
+name="badge-maker"
+required-features=['cli']
+
 [features]
 default = []
 cli = ["clap"]

--- a/src/badge/style.rs
+++ b/src/badge/style.rs
@@ -1,7 +1,7 @@
 use crate::badge::style::Style::*;
 use crate::error::Error;
 use crate::error::Error::BadStyleChoice;
-use serde::export::Formatter;
+use std::fmt::Formatter;
 use std::fmt::Display;
 
 /// Used to define the style of a badge. Used in [BadgeBuilder.style()](crate::badge::BadgeBuilder)


### PR DESCRIPTION
- use std::fmt::Formatter - as it was just reexport from std
- make bin target conditional on cli feature


Problem is with serde >= 1.0.119 - serde::export in now private module.