### PR TITLE
Fix build and cargo install.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use badge_maker::BadgeBuilder;
+use clap::Parser;
 
 #[derive(clap::Parser, Debug)]
 #[clap(name = "badge-maker")]


### PR DESCRIPTION
This fixes the following error:

```sh
# cargo build --features cli
   Compiling badge-maker v0.2.0 (/home/oni/VCS/rust-badge-maker)
error[E0599]: no function or associated item named `parse` found for struct `Opts` in the current scope
  --> src/main.rs:21:28
   |
5  | struct Opts {
   | ----------- function or associated item `parse` not found for this
...
21 |     let opts: Opts = Opts::parse();
   |                            ^^^^^ function or associated item not found in `Opts`
   |
   = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
   |
1  | use clap::Parser;
   |

For more information about this error, try `rustc --explain E0599`.
error: could not compile `badge-maker` due to previous error
```