### PR TITLE
New logos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,15 +27,15 @@ serde = { version = "1.0.133", features = ["derive"] }
 bincode = "1.3.3"
 aho-corasick = "0.7.18"
 seahash = "4.1.0"
-clap = { version = "3.0.4", features = ["derive"], optional = true }
+clap = { version = "3.2.2", features = ["derive"], optional = true }
 itoa = "0.4.7"
-
+base64 = "0.13.0"
 [[bench]]
 name = "bench"
 path = "benches/bench.rs"
 harness = false
 
 [dev-dependencies]
-criterion = "0.3"
-byte-unit = "4.0.9"
-itertools = "0.10.0"
+criterion = "0.3.5"
+byte-unit = "4.0.14"
+itertools = "0.10.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,14 @@ cli = ["clap"]
 
 [dependencies]
 lazy_static = "1.4.0"
-regex = "1.5.4"
-thiserror = "1.0.30"
-serde = { version = "1.0.133", features = ["derive"] }
+regex = "1.5.6"
+thiserror = "1.0.31"
+serde = { version = "1.0.137", features = ["derive"] }
 bincode = "1.3.3"
 aho-corasick = "0.7.18"
 seahash = "4.1.0"
 clap = { version = "3.2.2", features = ["derive"], optional = true }
-itoa = "0.4.7"
+itoa = "1.0.2"
 base64 = "0.13.0"
 [[bench]]
 name = "bench"
@@ -36,6 +36,6 @@ path = "benches/bench.rs"
 harness = false
 
 [dev-dependencies]
-criterion = "0.3.5"
-byte-unit = "4.0.14"
-itertools = "0.10.3"
+criterion = "0.3"
+byte-unit = "4.0.9"
+itertools = "0.10.0"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -70,9 +70,9 @@ pub fn bench_render_attributes(c: &mut Criterion) {
         b.iter(|| render_attributes_format(black_box(links), black_box("accessible accessible")))
     });
 
-    group.bench_function("render_attributes_new_fomat", |b| {
-        b.iter(|| render_attributes_new_fomat(black_box(links), black_box("accessible accessible")))
-    });
+   // group.bench_function("render_attributes_new_fomat", |b| {
+   //     b.iter(|| render_attributes_new_fomat(black_box(links), black_box("accessible accessible")))
+   // });
 
     group.bench_function("render_attributes_string", |b| {
         b.iter(|| render_attributes_string(black_box(links), black_box("accessible accessible")))
@@ -139,11 +139,11 @@ pub fn bench_render_badge(c: &mut Criterion) {
         b.iter(move || render_badge_old(black_box(param.clone()), black_box("main")))
     });
 
-    group.bench_function("render_badge_format_macros_crate", |b| {
-        b.iter(move || {
-            render_badge_format_macros_crate(black_box(param.clone()), black_box("main"))
-        })
-    });
+   // group.bench_function("render_badge_format_macros_crate", |b| {
+   //     b.iter(move || {
+   //         render_badge_format_macros_crate(black_box(param.clone()), black_box("main"))
+   //     })
+   // });
 
     group.bench_function("render_badge_new", |b| {
         b.iter(move || render_badge_new(black_box(param), black_box("main")))

--- a/src/badge/badge.rs
+++ b/src/badge/badge.rs
@@ -1,4 +1,3 @@
-use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use crate::badge::color::util::u64_to_hex;
 use crate::badge::style::Style;
@@ -6,7 +5,6 @@ use crate::badge::{Links, Logo};
 
 use crate::render::renderers::styles::*;
 use crate::render::BadgeRenderer;
-use seahash::hash;
 
 /// The purpose of a unique id is to make the svg compatible with direct website embedding.
 ///

--- a/src/badge/badge.rs
+++ b/src/badge/badge.rs
@@ -1,3 +1,5 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use crate::badge::color::util::u64_to_hex;
 use crate::badge::style::Style;
 use crate::badge::{Links, Logo};
@@ -18,42 +20,16 @@ fn gen_id(
     links: &Links,
     logo: &Option<Logo>,
 ) -> String {
-    let Logo {
-        url,
-        width,
-        padding,
-    } = logo.as_ref().cloned().unwrap_or(Logo {
-        url: "not_set".to_string(),
-        width: 0,
-        padding: 0,
-    });
-
-    let buf = vec![
-        label.as_ref().unwrap_or(&"not_set".to_string()).as_bytes(),
-        message.as_bytes(),
-        label_color.as_bytes(),
-        color.as_bytes(),
-        style.to_string().as_bytes(),
-        links
-            .left
-            .as_ref()
-            .unwrap_or(&"not_set".to_string())
-            .as_bytes(),
-        links
-            .right
-            .as_ref()
-            .unwrap_or(&"not_set".to_string())
-            .as_bytes(),
-        url.as_bytes(),
-        &width.to_be_bytes(),
-        &padding.to_be_bytes(),
-    ]
-    .iter()
-    .cloned()
-    .flatten()
-    .cloned()
-    .collect::<Vec<u8>>();
-    u64_to_hex(hash(&buf))
+    let mut hasher = seahash::SeaHasher::new();
+    logo.hash(&mut hasher);
+    label.hash(&mut hasher);
+    label_color.hash(&mut hasher);
+    color.hash(&mut hasher);
+    style.hash(&mut hasher);
+    message.hash(&mut hasher);
+    links.left.hash(&mut hasher);
+    links.right.hash(&mut hasher);
+    u64_to_hex(hasher.finish())
 }
 
 /// Badges are valid and have all the necessary
@@ -187,11 +163,11 @@ mod tests {
                 &Flat,
                 &Links {
                     left: Option::from("hello".to_string()),
-                    right: None
+                    right: None,
                 },
-                &None
+                &None,
             ),
-            "e3f9ab42ba6abd5a"
+            "95efd3465e2fbf49"
         );
         assert_eq!(
             gen_id(
@@ -202,11 +178,11 @@ mod tests {
                 &Flat,
                 &Links {
                     left: None,
-                    right: None
+                    right: None,
                 },
-                &None
+                &None,
             ),
-            "a387ad147f28ca08"
+            "81df87a2241d1ad9"
         );
     }
 }

--- a/src/badge/badge_builder.rs
+++ b/src/badge/badge_builder.rs
@@ -70,7 +70,7 @@ impl BadgeBuilder {
     }
 
     pub fn label_color_parse(&mut self, label_color: &str) -> &mut Self {
-        self.label_color_parse = Some(label_color.to_lowercase().replace(" ", ""));
+        self.label_color_parse = Some(label_color.to_lowercase().replace(' ', ""));
         self
     }
 
@@ -80,7 +80,7 @@ impl BadgeBuilder {
     }
 
     pub fn color_parse(&mut self, color: &str) -> &mut Self {
-        self.color_parse = Some(color.to_lowercase().replace(" ", ""));
+        self.color_parse = Some(color.to_lowercase().replace(' ', ""));
         self
     }
 

--- a/src/badge/badge_builder.rs
+++ b/src/badge/badge_builder.rs
@@ -84,8 +84,8 @@ impl BadgeBuilder {
         self
     }
 
-    pub fn color(&mut self, color: Color) -> &mut Self {
-        self.color = Some(color);
+    pub fn color<Col: Into<Color>>(&mut self, color: Col) -> &mut Self {
+        self.color = Some(color.into());
         self
     }
 
@@ -108,17 +108,17 @@ impl BadgeBuilder {
         self.logo = Some(logo);
         self
     }
-
+    #[deprecated(since = "0.2.2", note = "Set the logo instead")]
     pub fn logo_url(&mut self, url: &str) -> &mut Self {
         self.logo_url = Some(url.trim().to_string());
         self
     }
-
+    #[deprecated(since = "0.2.2", note = "Set the logo instead")]
     pub fn logo_width(&mut self, width: usize) -> &mut Self {
         self.logo_width = Some(width);
         self
     }
-
+    #[deprecated(since = "0.2.2", note = "Set the logo instead")]
     pub fn logo_padding(&mut self, padding: isize) -> &mut Self {
         self.logo_padding = Some(padding);
         self
@@ -197,7 +197,7 @@ impl BadgeBuilder {
         } else if let Some(url) = self.logo_url.as_ref() {
             let width = self.logo_width.unwrap_or(DEFAULT_LOGO_WIDTH);
             let padding = self.logo_padding.unwrap_or(DEFAULT_LOGO_PADDING);
-            Some(Logo::new(url.to_string(), width, padding))
+            Some(Logo::LogoImage { url: url.to_string(), width, padding })
         } else {
             None
         };
@@ -244,9 +244,9 @@ mod tests {
                 Style::Flat,
                 Links {
                     left: None,
-                    right: None
+                    right: None,
                 },
-                None
+                None,
             )
         );
     }
@@ -269,9 +269,9 @@ mod tests {
                 Style::Flat,
                 Links {
                     left: None,
-                    right: None
+                    right: None,
                 },
-                None
+                None,
             )
         );
 
@@ -291,9 +291,9 @@ mod tests {
                 Style::Flat,
                 Links {
                     left: None,
-                    right: None
+                    right: None,
                 },
-                None
+                None,
             )
         );
 
@@ -313,9 +313,9 @@ mod tests {
                 Style::Flat,
                 Links {
                     left: None,
-                    right: None
+                    right: None,
                 },
-                None
+                None,
             )
         );
     }

--- a/src/badge/color/color.rs
+++ b/src/badge/color/color.rs
@@ -1,11 +1,32 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum Color {
     Named(NamedColor),
     Alias(AliasColor),
     Rgb(u8, u8, u8),
 }
 
+impl Display for Color {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Color::Named(named) => {
+                write!(f, "{}", named.hex())
+            }
+
+            Color::Alias(alias) => {
+                write!(f, "{}", alias.hex())
+            }
+            Color::Rgb(r, g, b) => {
+                write!(f, "rgb({},{},{})", r, g, b)
+            }
+        }
+    }
+}
+
 /// Colors from the
 /// [badge-maker](https://github.com/badges/shields/blob/master/badge-maker/lib/color.js) spec
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum NamedColor {
     BrightGreen,
     Green,
@@ -18,6 +39,7 @@ pub enum NamedColor {
     LightGrey,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum AliasColor {
     Gray,
     LightGray,
@@ -55,5 +77,23 @@ impl AliasColor {
             AliasColor::Informational => NamedColor::Blue.hex(),
             AliasColor::Inactive => NamedColor::LightGrey.hex(),
         }
+    }
+}
+
+impl From<AliasColor> for Color {
+    fn from(alias: AliasColor) -> Self {
+        Color::Alias(alias)
+    }
+}
+
+impl From<NamedColor> for Color {
+    fn from(named: NamedColor) -> Self {
+        Color::Named(named)
+    }
+}
+
+impl From<(u8, u8, u8)> for Color {
+    fn from((r, g, b): (u8, u8, u8)) -> Self {
+        Self::Rgb(r, g, b)
     }
 }

--- a/src/badge/logo.rs
+++ b/src/badge/logo.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use crate::color::Color;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -50,7 +49,7 @@ impl Logo {
     pub fn url(&self) -> &str {
         match self {
             Self::LogoImage { url, .. } => url,
-            Self::SVGLogo { svg, .. } => panic!("SVGLogo::url() called on SVGLogo"),
+            Self::SVGLogo { .. } => panic!("SVGLogo::url() called on SVGLogo"),
         }
     }
 

--- a/src/badge/logo.rs
+++ b/src/badge/logo.rs
@@ -9,6 +9,8 @@ pub enum Logo {
     },
     /// SVG Based Logo
     /// If the color attribute is set it will try to add one. This allows for changing of the fill color of the SVG.
+    ///
+    /// Simple Icons provides a list of SVG based logos: https://simpleicons.org/
     /// ```rust
     ///  use badge_maker::error::Error;
     /// use badge_maker::{BadgeBuilder, Logo};
@@ -19,6 +21,7 @@ pub enum Logo {
     ///     width: 100,
     ///    padding: 10,
     /// }).build().unwrap();
+    ///
     /// println!("{}", badge.svg());
     ///
     /// ```

--- a/src/badge/logo.rs
+++ b/src/badge/logo.rs
@@ -1,26 +1,70 @@
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Logo {
-    pub(crate) url: String,
-    pub(crate) width: usize,
-    pub(crate) padding: isize,
+use std::borrow::Cow;
+use crate::color::Color;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum Logo {
+    LogoImage {
+        url: String,
+        width: usize,
+        padding: isize,
+    },
+    /// SVG Based Logo
+    /// If the color attribute is set it will try to add one. This allows for changing of the fill color of the SVG.
+    /// ```rust
+    ///  use badge_maker::error::Error;
+    /// use badge_maker::{BadgeBuilder, Logo};
+    /// use badge_maker::color::{Color, NamedColor};
+    /// let badge = BadgeBuilder::new().message("Chrome").color(Color::Rgb(0,0,0)).logo(Logo::SVGLogo {
+    ///     svg: r#"<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Google Chrome</title><path d="M12 0C8.21 0 4.831 1.757 2.632 4.501l3.953 6.848A5.454 5.454 0 0 1 12 6.545h10.691A12 12 0 0 0 12 0zM1.931 5.47A11.943 11.943 0 0 0 0 12c0 6.012 4.42 10.991 10.189 11.864l3.953-6.847a5.45 5.45 0 0 1-6.865-2.29zm13.342 2.166a5.446 5.446 0 0 1 1.45 7.09l.002.001h-.002l-5.344 9.257c.206.01.413.016.621.016 6.627 0 12-5.373 12-12 0-1.54-.29-3.011-.818-4.364zM12 16.364a4.364 4.364 0 1 1 0-8.728 4.364 4.364 0 0 1 0 8.728Z"/></svg>"#.to_string(),
+    ///     color: Some(NamedColor::Yellow.into()),
+    ///     width: 100,
+    ///    padding: 10,
+    /// }).build().unwrap();
+    /// println!("{}", badge.svg());
+    ///
+    /// ```
+    SVGLogo {
+        svg: String,
+        color: Option<Color>,
+        width: usize,
+        padding: isize,
+    },
 }
 
 impl Logo {
+    #[deprecated(
+    since = "0.2.2",
+    note = "Use the Enum Type `Logo::LogoImage` instead"
+    )]
     pub fn new(url: String, width: usize, padding: isize) -> Self {
-        Self {
+        Self::LogoImage {
             url,
             width,
             padding,
         }
     }
-
+    #[deprecated(
+    since = "0.2.2",
+    note = "New Logo Type Makes this function obsolete. "
+    )]
     pub fn url(&self) -> &str {
-        &self.url
+        match self {
+            Self::LogoImage { url, .. } => url,
+            Self::SVGLogo { svg, .. } => panic!("SVGLogo::url() called on SVGLogo"),
+        }
     }
+
     pub fn width(&self) -> usize {
-        self.width
+        match self {
+            Self::LogoImage { width, .. } => *width,
+            Self::SVGLogo { width, .. } => *width,
+        }
     }
+
     pub fn padding(&self) -> isize {
-        self.padding
+        match self {
+            Self::LogoImage { padding, .. } => *padding,
+            Self::SVGLogo { padding, .. } => *padding,
+        }
     }
 }

--- a/src/badge/style.rs
+++ b/src/badge/style.rs
@@ -4,7 +4,7 @@ use crate::error::Error::BadStyleChoice;
 use std::fmt::{Display, Formatter};
 
 /// Used to define the style of a badge. Used in [BadgeBuilder.style()](crate::badge::BadgeBuilder)
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq,Hash)]
 pub enum Style {
     Flat,
     Plastic,

--- a/src/render/base.rs
+++ b/src/render/base.rs
@@ -98,7 +98,7 @@ impl BaseConfig {
 
         let width = left_width + right_width;
 
-        let accessible_text = create_accessible_text(&badge.label(), &badge.message());
+        let accessible_text = create_accessible_text(badge.label(), badge.message());
 
         BaseConfig {
             left_width,

--- a/src/render/renderers/badge.rs
+++ b/src/render/renderers/badge.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write;
+use itoa::Buffer;
 use crate::badge::Links;
 use crate::render::renderers::{render_attributes, render_title};
 use crate::render::util::xml::strip_xml_whitespace;
@@ -58,12 +60,13 @@ pub fn render_badge(config: RenderBadgeConfig, main: &str) -> String {
     );
 
     #[cfg(debug_assertions)]
+    let mut itoa_buffer = Buffer::new();
     let start_cap = buffer.capacity();
-
     buffer.push_str(r##"<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width=""##);
-    itoa::fmt(&mut buffer, width).unwrap();
+
+    buffer.write_str(itoa_buffer.format(width)).unwrap();
     buffer.push_str(r#"" height=""#);
-    itoa::fmt(&mut buffer, config.height).unwrap();
+    buffer.write_str(itoa_buffer.format(config.height)).unwrap();
     buffer.push_str(r#"" "#);
 
     buffer.push_str(&attributes);

--- a/src/render/renderers/links.rs
+++ b/src/render/renderers/links.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write;
+use itoa::Buffer;
 use crate::render::util::xml::escape_xml;
 
 pub struct RenderLinkConfig<'a> {
@@ -28,17 +30,17 @@ pub fn render_link(config: RenderLinkConfig) -> String {
     );
     #[cfg(debug_assertions)]
     let start_cap = buffer.capacity();
-
+    let mut itoa_buffer = Buffer::new();
     buffer.push_str(r#"<a target="_blank" xlink:href=""#);
     buffer.push_str(&escaped_link);
     buffer.push_str(r#""><rect width=""#);
-    itoa::fmt(&mut buffer, rect_width).unwrap();
+    buffer.write_str(itoa_buffer.format(rect_width)).unwrap();
     buffer.push_str(r#"" x=""#);
-    itoa::fmt(&mut buffer, rect_x).unwrap();
+    buffer.write_str(itoa_buffer.format(rect_x)).unwrap();
     buffer.push_str(r#"" height=""#);
-    itoa::fmt(&mut buffer, rect_height).unwrap();
+    buffer.write_str(itoa_buffer.format(rect_height)).unwrap();
     buffer.push_str(r#"" fill="rgba(0,0,0,0)"/>"#);
-    buffer.push_str(&config.rendered_text);
+    buffer.push_str(config.rendered_text);
     buffer.push_str(r#"</a>"#);
 
     #[cfg(debug_assertions)]

--- a/src/render/renderers/logo.rs
+++ b/src/render/renderers/logo.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write;
+use itoa::Buffer;
 use crate::badge::Logo;
 use crate::render::util::xml::{escape_xml, replace_fill_attribute};
 
@@ -47,15 +49,16 @@ pub fn render_logo(config: RenderLogoConfig) -> RenderLogoReturn {
 
     #[cfg(debug_assertions)]
     let start_cap = buffer.capacity();
+    let mut itoa_buffer = Buffer::new();
 
     buffer.push_str(r#"<image x=""#);
-    itoa::fmt(&mut buffer, x).unwrap();
+    buffer.write_str(itoa_buffer.format(x)).unwrap();
     buffer.push_str(r#"" y=""#);
-    itoa::fmt(&mut buffer, y).unwrap();
+    buffer.write_str(itoa_buffer.format(y)).unwrap();
     buffer.push_str(r#"" width=""#);
-    itoa::fmt(&mut buffer, logo.width()).unwrap();
+    buffer.write_str(itoa_buffer.format(logo.width())).unwrap();
     buffer.push_str(r#"" height=""#);
-    itoa::fmt(&mut buffer, logo_height).unwrap();
+    buffer.write_str(itoa_buffer.format(logo_height)).unwrap();
     buffer.push_str(r#"" xlink:href=""#);
     buffer.push_str(&escaped_logo);
     buffer.push_str(r#""/>"#);

--- a/src/render/renderers/text.rs
+++ b/src/render/renderers/text.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write;
+use itoa::Buffer;
 use crate::render::font::Font;
 
 use crate::render::renderers::{render_link, RenderLinkConfig};
@@ -90,8 +92,8 @@ pub fn render_text(config: RenderTextConfig) -> RenderTextReturn {
         };
     }
 
-    let text_length = preferred_width(&config.content, config.font);
-    let escaped_content = escape_xml(&config.content);
+    let text_length = preferred_width(config.content, config.font);
+    let escaped_content = escape_xml(config.content);
 
     let shadow_margin = 150 + config.vertical_margin;
     let text_margin = 140 + config.vertical_margin;
@@ -100,7 +102,7 @@ pub fn render_text(config: RenderTextConfig) -> RenderTextReturn {
     let x = 10.0
         * (config.left_margin as f32 + 0.5 * text_length as f32 + config.horizontal_padding as f32);
 
-    let TextColoring { text, shadow } = colors_for_background(&config.color);
+    let TextColoring { text, shadow } = colors_for_background(config.color);
 
     let buffer_capacity = if config.shadow {
         160 + 150 + escaped_content.len() * 2
@@ -112,29 +114,30 @@ pub fn render_text(config: RenderTextConfig) -> RenderTextReturn {
 
     #[cfg(debug_assertions)]
     let start_cap = buffer.capacity();
+    let mut itoa_buffer = Buffer::new();
 
     if config.shadow {
         buffer.push_str(r#"<text aria-hidden="true" x=""#);
-        itoa::fmt(&mut buffer, x as u32).unwrap_or(());
+        buffer.write_str(itoa_buffer.format(x as u32)).unwrap_or(());
         buffer.push_str(r#"" y=""#);
-        itoa::fmt(&mut buffer, shadow_margin).unwrap_or(());
+        buffer.write_str(itoa_buffer.format(shadow_margin as u32)).unwrap_or(());
         buffer.push_str(r#"" fill=""#);
         buffer.push_str(shadow);
         buffer.push_str(r#"" fill-opacity=".3" transform="scale(.1)" textLength=""#);
-        itoa::fmt(&mut buffer, out_text_length).unwrap_or(());
+        buffer.write_str(itoa_buffer.format(out_text_length as u32)).unwrap_or(());
         buffer.push_str(r#"">"#);
         buffer.push_str(&escaped_content);
         buffer.push_str("</text>");
     };
 
     buffer.push_str(r#"<text x=""#);
-    itoa::fmt(&mut buffer, x as u32).unwrap_or(());
+    buffer.write_str(itoa_buffer.format(x as u32)).unwrap_or(());
     buffer.push_str(r#"" y=""#);
-    itoa::fmt(&mut buffer, text_margin).unwrap_or(());
+    buffer.write_str(itoa_buffer.format(text_margin as u32)).unwrap_or(());
     buffer.push_str(r#"" transform="scale(.1)" fill=""#);
     buffer.push_str(text);
     buffer.push_str(r#"" textLength=""#);
-    itoa::fmt(&mut buffer, out_text_length).unwrap_or(());
+    buffer.write_str(itoa_buffer.format(out_text_length as u32)).unwrap_or(());
     buffer.push_str(r#"">"#);
     buffer.push_str(&escaped_content);
     buffer.push_str(r#"</text>"#);

--- a/src/render/util/xml.rs
+++ b/src/render/util/xml.rs
@@ -45,7 +45,7 @@ fn strip_xml_trailing_aho(s: &str) -> String {
             .build(&XML_STRIP_TRAILING_PATTERNS.0);
     }
 
-    AC.replace_all(&s, &XML_STRIP_TRAILING_PATTERNS.1)
+    AC.replace_all(s, &XML_STRIP_TRAILING_PATTERNS.1)
 }
 
 pub(crate) fn escape_xml(s: &str) -> String {


### PR DESCRIPTION
1. So I updated the depend itoa. In 1.0.0 they drop the fmt function. I replaced the code with the equivalent https://docs.rs/itoa/0.4.7/src/itoa/lib.rs.html#90-93 
2. Closes #10 
3. Redid the gen_id function. I did this to make it more easily compatible with the new logo api. 
4. Changed the color function in the badge builder to take a generic for Into<Color>. To allow for easier setting of colors. 
5. Removed some clippy warnings. 
None of this could should be breaking. 

Gen_ID could possible break something. However, I don't see that happening. 